### PR TITLE
JCF: allow cogs to be built within the existing CMake-based DUNE DAQ …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.12)
+project(cogs VERSION 1.0.0)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../daq-buildtools/cmake ${CMAKE_MODULE_PATH})
+include(DAQ)
+
+daq_setup_environment()
+
+find_package(ers REQUIRED)
+
+find_package(nlohmann_json 3.8.0 )
+
+if(NOT ${nlohmann_json_FOUND})
+  message("nlohmann_json NOT FOUND! Downloading single-header from GitHub!")
+  file(DOWNLOAD https://github.com/nlohmann/json/raw/v3.8.0/single_include/nlohmann/json.hpp nlohmann/json.hpp)
+  include_directories(${CMAKE_BINARY_DIR})
+endif()
+
+# Can delete this include_directories line when "./inc" gets renamed "./include"
+include_directories( ./inc )
+
+
+##############################################################################
+daq_point_build_to( src )
+
+add_library(cogs src/stream.cpp)
+target_link_libraries(cogs ers::ers)
+target_include_directories(cogs PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
+
+##############################################################################
+daq_point_build_to( demo )
+
+add_executable(cogs-demo demo/cogs-demo.cpp demo/comp.cpp  demo/factory.cpp  demo/node.cpp)
+target_link_libraries(cogs-demo cogs)
+
+install(FILES       demo/generate.sh demo/clean.sh 
+        DESTINATION ./demo 
+        PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
+
+install(FILES       demo/comp-schema.jsonnet demo/demo-config.jsonnet demo/node-schema.jsonnet demo/demo-codegen.jsonnet demo/head-schema.jsonnet 
+	DESTINATION ./demo
+        PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)      
+
+##############################################################################
+daq_point_build_to( test )
+
+function( cogs_add_test testlabel )
+  add_executable(test_${testlabel} test/test_${testlabel}.cpp)
+  target_link_libraries(test_${testlabel} cogs)
+endfunction()
+
+cogs_add_test(stream)
+cogs_add_test(nljs_sub)
+cogs_add_test(logging)
+cogs_add_test(exceptions)
+
+##############################################################################
+
+daq_install( TARGETS cogs-demo cogs )
+
+# Can delete this include_directories line when "./inc" gets renamed "./include"
+install(DIRECTORY inc/${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h??")

--- a/cogsConfig.cmake.in
+++ b/cogsConfig.cmake.in
@@ -1,0 +1,19 @@
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(ers)
+
+find_package(nlohmann_json 3.8.0 )
+
+if(NOT ${nlohmann_json_FOUND})
+  message("nlohmann_json NOT FOUND! Downloading single-header from GitHub!")
+  file(DOWNLOAD https://github.com/nlohmann/json/raw/v3.8.0/single_include/nlohmann/json.hpp nlohmann/json.hpp)
+  include_directories(${CMAKE_BINARY_DIR})
+endif()
+
+set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+include(${targets_file})
+
+check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
…build framework

With this commit, it's possible to build cogs by the doing the following, once you're in an empty directory on a system with access to the /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products ups products area:
```
curl -O https://raw.githubusercontent.com/DUNE-DAQ/daq-buildtools/develop/bin/quick-start.sh
chmod +x quick-start.sh
./quick-start.sh
. ./setup_build_environment
# ...where this comment is, imagine you clone the cogs repo and get onto a branch with this pull request's code...
./build_daq_software.sh --install --pkgname cogs
. ./setup_runtime_environment
```
and then if you develop other packages in the development area you set up, you can access the cogs library like so in a given package's CMakeLists.txt file:
```
find_package(cogs REQUIRED)
```
so then you can, e.g., 
```
add_executable(        cool_program_that_uses_cogs   cool_program_that_uses_cogs.cpp)
target_link_libraries( cool_program_that_uses_cogs   cogs::cogs)  # <namespace>::<installed target>
```

Please note that because (currently) installation of a repo is performed in your local area, the installed cogs package will be in `./install/cogs`. Consequently the locations of the files referred to in the online documentation at https://brettviren.github.io/cogs/demo.html are a bit different:
* ./install/bin/cogs-demo                   ->     ./install/cogs/bin/cogs-demo
* demo/*.sh, *.hpp, *.json, *.jsonnet   ->    ./install/cogs/demo/\*.sh, *.hpp, *.json, *.jsonnet
* inc/                                                    ->     ./install/cogs/include